### PR TITLE
Choose a mixer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,24 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<mainClass>com.shuffle.scplayer.SCPlayerMain</mainClass>
+						</manifest>
+						<manifestEntries>
+							<Class-Path>.</Class-Path>
+						</manifestEntries>
+					</archive>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/src/main/java/com/shuffle/scplayer/SCPlayerMain.java
+++ b/src/main/java/com/shuffle/scplayer/SCPlayerMain.java
@@ -27,6 +27,7 @@ public class SCPlayerMain {
 		initLogger();
 
 		String playerName = System.getProperty("playerName", "SCPlayer");
+		String mixer = System.getProperty("mixer");
 		String username = System.getProperty("username");
 		String password = System.getProperty("password");
 		Boolean standalone = Boolean.getBoolean("standalone");
@@ -44,6 +45,9 @@ public class SCPlayerMain {
 
 		if (playerName != null && !"".equalsIgnoreCase(playerName)) {
 			player.setPlayerName(playerName);
+		}
+		if (mixer != null && !"".equalsIgnoreCase(mixer)) {
+			player.setMixer(mixer);
 		}
 		if (username != null && !"".equalsIgnoreCase(username) && password != null && !"".equalsIgnoreCase(password)) {
 			player.login(username, password);

--- a/src/main/java/com/shuffle/scplayer/core/AudioPlayer.java
+++ b/src/main/java/com/shuffle/scplayer/core/AudioPlayer.java
@@ -22,7 +22,6 @@ public class AudioPlayer implements AudioListener {
     private final SpotifyConnectPlayer player;
 
     private AudioFormat pcm = new AudioFormat(RATE, 16, CHANNELS, true, false);
-    private DataLine.Info info = new DataLine.Info(SourceDataLine.class, pcm);
     private SourceDataLine audioLine;
     private PipedInputStream input;
     private PipedOutputStream output;
@@ -150,7 +149,10 @@ public class AudioPlayer implements AudioListener {
     @Override
     public void onActive() {
         try {
-            audioLine = (SourceDataLine) AudioSystem.getLine(info);
+            if (player.getMixer() != null)
+                audioLine = AudioSystem.getSourceDataLine(pcm, player.getMixer());
+            else
+                audioLine = AudioSystem.getSourceDataLine(pcm);
             audioLine.open(pcm);
             onVolumeChanged(player.getVolume());
             if (isMuted && audioLine.isControlSupported(BooleanControl.Type.MUTE))

--- a/src/main/java/com/shuffle/scplayer/core/SpotifyConnectPlayer.java
+++ b/src/main/java/com/shuffle/scplayer/core/SpotifyConnectPlayer.java
@@ -1,5 +1,7 @@
 package com.shuffle.scplayer.core;
 
+import javax.sound.sampled.Mixer;
+
 /**
  * @author crsmoro
  * @author LeanderK
@@ -57,4 +59,8 @@ public interface SpotifyConnectPlayer {
     AudioListener getAudioListener();
 
     void setAudioListener(AudioListener audioListener);
+
+    void setMixer(String outputDevice);
+
+    Mixer.Info getMixer();
 }

--- a/src/main/java/com/shuffle/scplayer/core/SpotifyConnectPlayerImpl.java
+++ b/src/main/java/com/shuffle/scplayer/core/SpotifyConnectPlayerImpl.java
@@ -48,6 +48,7 @@ public class SpotifyConnectPlayerImpl implements SpotifyConnectPlayer {
     private boolean threadPumpEventsStop = false;
     
     private final File credentials = new File("./credentials.json");
+    private Mixer.Info mixerInfo;
 
     public SpotifyConnectPlayerImpl() {
         this(new File("./spotify_appkey.key"), "spotify_embedded_shared");
@@ -599,5 +600,20 @@ public class SpotifyConnectPlayerImpl implements SpotifyConnectPlayer {
     @Override
     public void setAudioListener(AudioListener audioListener) {
         this.audioListener = audioListener;
+    }
+
+    @Override
+    public void setMixer(String mixerName) {
+        for (Mixer.Info mixerInfo : AudioSystem.getMixerInfo())
+            if (mixerInfo.getName().equals(mixerName)) {
+                this.mixerInfo = mixerInfo;
+                return;
+            }
+        throw new IllegalArgumentException("Bad mixer " + mixerName);
+    }
+
+    @Override
+    public Mixer.Info getMixer() {
+        return mixerInfo;
     }
 }


### PR DESCRIPTION
Hi,

Thank you for your implementation, it's really nice to use spotify connect on my rpi.

However, I have two sound cards (builtin hdmi and a hifiberry one) and since both are useful for my setup, I wanted to be able to choose which one should be used.
Since java doesn't seems to follow alsa preferences (as specified in ~/.asoundrc), I added the possibility to choose via the command line.

If you think it's useful but the implementation doesn't please you, please let me know and I will gladly change it in order to satisfy your requirements.
